### PR TITLE
Remove ctx on Session.cancel calls as it's not an argument anymore

### DIFF
--- a/discord/ext/buttons/buttons.py
+++ b/discord/ext/buttons/buttons.py
@@ -115,7 +115,7 @@ class Session:
                 future.cancel()
 
             if not done:
-                return ctx.bot.loop.create_task(self.cancel(ctx))
+                return ctx.bot.loop.create_task(self.cancel())
 
             try:
                 result = done.pop()
@@ -126,7 +126,7 @@ class Session:
                 else:
                     action = False
             except Exception:
-                return ctx.bot.loop.create_task(self.cancel(ctx))
+                return ctx.bot.loop.create_task(self.cancel())
 
             emoji = self.get_emoji_as_string(payload.emoji)
             button = self.buttons[emoji]


### PR DESCRIPTION
The argument `ctx` was removed from `Session.cancel` on commit 2a50b03 but it was still present in the changed lines